### PR TITLE
Rename actions

### DIFF
--- a/src/actions/backupFiles.js
+++ b/src/actions/backupFiles.js
@@ -26,7 +26,6 @@ export default async function backupFiles(
 
   // Upload handler for .ai files
   const handleUpload = async (file) => {
-    console.log('Upload', file);
     const filePath = await join(projectPath, file, `${file}.ai`);
     const content = await readBinaryFile(filePath);
 

--- a/src/actions/backupFiles.js
+++ b/src/actions/backupFiles.js
@@ -26,6 +26,7 @@ export default async function backupFiles(
 
   // Upload handler for .ai files
   const handleUpload = async (file) => {
+    console.log('Upload', file);
     const filePath = await join(projectPath, file, `${file}.ai`);
     const content = await readBinaryFile(filePath);
 

--- a/src/actions/createIllustration.js
+++ b/src/actions/createIllustration.js
@@ -17,6 +17,8 @@ export default async function createIllustration(
   projectSlug,
   illustrationName,
 ) {
+  await store.addIllustration({ projectSlug, illustrationName });
+
   const projectsFolder = await getWorkingProjectPath(projectSlug);
   const illustrationSlug = slugify(illustrationName);
   const illustrationFileName = `${illustrationSlug}.ai`;
@@ -34,6 +36,4 @@ export default async function createIllustration(
     key: `${ARCHIVE_TEMPLATES_DIRECTORY}/${ARTISAN_BASE_TEMPLATE_NAME}`,
   });
   await writeBinaryFile(destinationFile, template);
-
-  store.addIllustration({ projectSlug, illustrationName });
 }

--- a/src/actions/createProject.js
+++ b/src/actions/createProject.js
@@ -1,17 +1,16 @@
 import { join } from '@tauri-apps/api/path';
 import { createDir } from '@tauri-apps/api/fs';
-import slugify from '../utils/text/slugify';
 import store from '../store';
 
 export default async function createProject(projectName) {
   const projectsFolder = await store.getWorkingDir();
 
+  const { slug } = await store.addProject(projectName, { method: 'create' });
+
   const projPath = await join(
     projectsFolder,
-    slugify(projectName),
+    slug,
   );
 
   await createDir(projPath);
-
-  return store.addProject(projectName);
 }

--- a/src/actions/deleteIllustration.js
+++ b/src/actions/deleteIllustration.js
@@ -12,7 +12,8 @@ export default async function deleteIllustration(
   const illustrationDirPath = await join(projectFolder, illustrationSlug);
 
   const confirmed = await confirm(
-    'This will delete the Adobe Illustrator from your computer. Are you sure?',
+    'This will delete the Adobe Illustrator file from your computer.'
+     + ' Are you sure?',
     { title: 'Delete illustration', type: 'warning' },
   );
 

--- a/src/actions/deleteProject.js
+++ b/src/actions/deleteProject.js
@@ -19,7 +19,8 @@ export default async function deleteProject(
 
   if (!isAfterArchive) {
     confirmed = await confirm(
-      'This will delete the project from your computer and all associated illustrator files. Are you sure?',
+      'This will delete the project from your computer and all'
+      + ' associated illustrator files. Are you sure?',
       { title: 'Delete Project', type: 'warning' },
     );
   }

--- a/src/actions/downloadProject.js
+++ b/src/actions/downloadProject.js
@@ -40,7 +40,9 @@ export default async function downloadProject(projectSlug) {
     key: `${keyPath}/`,
   });
 
-  await store.addProject(Metadata.name, { isUploaded: true });
+  await store.addProject(
+    Metadata.name, { isUploaded: true, method: 'download' },
+  );
 
   // Start of downloading illustrator files
   const projectPath = await getWorkingProjectPath(projectSlug);

--- a/src/actions/duplicateProject.js
+++ b/src/actions/duplicateProject.js
@@ -46,7 +46,7 @@ export default async function duplicateProject(
 
   const illosToAdd = illos.flat().filter((d) => d);
 
-  await store.addProject(newProjectSlug);
+  await store.addProject(newProjectSlug, { method: 'duplicate' });
   // Add illos to store one by one
   await runPromisesSequentially(illosToAdd.map(
     (illustrationName) => () => store.addIllustration(

--- a/src/actions/getProjectsArchive.js
+++ b/src/actions/getProjectsArchive.js
@@ -3,24 +3,14 @@ import { AWS_ARTISAN_BUCKET } from '../constants/aws';
 import { ARCHIVE_PROJECTS_DIRECTORY } from '../constants/paths';
 import store from '../store';
 import s3 from '../utils/s3';
+import fetchProjectsArchive from '../utils/archive/fetchProjectsArchive';
 
 /**
  * Fetches list of projects in the archive by slug name
  * @returns {Array<Object>}
  */
 export default async function getProjectsArchive() {
-  const params = {
-    bucket: AWS_ARTISAN_BUCKET,
-    delimiter: '/',
-    prefix: `${ARCHIVE_PROJECTS_DIRECTORY}/`,
-  };
-
-  const projectsPrefixes = await s3.list(params);
-
-  const projectsList = projectsPrefixes?.CommonPrefixes.map((d) => {
-    const path = d.Prefix;
-    return path.replace(`${ARCHIVE_PROJECTS_DIRECTORY}/`, '').replace('/', '');
-  });
+  const projectsList = await fetchProjectsArchive();
 
   // compare to projects in store
   const localProjects = (await store.getProjectsList()) || [];

--- a/src/actions/renameIllustration.js
+++ b/src/actions/renameIllustration.js
@@ -1,0 +1,33 @@
+import { renameFile } from '@tauri-apps/api/fs';
+import { join } from '@tauri-apps/api/path';
+
+import store from '../store';
+
+export default async function renameIllustration(
+  projectSlug,
+  illustrationSlug,
+  newName,
+) {
+  const illoInfo = await store.renameIllustration({
+    project: projectSlug,
+    slug: illustrationSlug,
+    name: newName,
+  });
+
+  const { slug: newIlloSlug } = illoInfo;
+
+  const projectFolder = await join(
+    await store.getWorkingDir(),
+    projectSlug,
+  );
+
+  await renameFile(
+    await join(projectFolder, illustrationSlug),
+    await join(projectFolder, newIlloSlug),
+  );
+
+  await renameFile(
+    await join(projectFolder, newIlloSlug, `${illustrationSlug}.ai`),
+    await join(projectFolder, newIlloSlug, `${newIlloSlug}.ai`),
+  );
+}

--- a/src/actions/renameProject.js
+++ b/src/actions/renameProject.js
@@ -1,0 +1,19 @@
+import { renameFile } from '@tauri-apps/api/fs';
+import { join } from '@tauri-apps/api/path';
+
+import store from '../store';
+
+export default async function renameProject(projectSlug, newName) {
+  const { slug } = await store.renameProject({
+    slug: projectSlug,
+    name: newName,
+  });
+
+  const projectsFolder = await store.getWorkingDir();
+  const projectFolder = await join(projectsFolder, projectSlug);
+
+  await renameFile(
+    projectFolder,
+    await join(projectsFolder, slug),
+  );
+}

--- a/src/components/ActionTestingView/index.jsx
+++ b/src/components/ActionTestingView/index.jsx
@@ -229,6 +229,22 @@ export default function ActionTestingView() {
           name="Rename To Existing Project"
           onClick={() => renameProject('new-project', 'project-one')}
         />
+        <TestButton
+          name="Rename To Existing Illustration"
+          onClick={() => renameIllustration(
+            'project-one',
+            'my-second-illustration',
+            'My Cool Illustration',
+          )}
+        />
+        <TestButton
+          name="Rename Backed Up Illustration"
+          onClick={() => renameIllustration(
+            'project-one',
+            'my-second-illustration',
+            'My Third Illustration',
+          )}
+        />
       </div>
     </div>
   );

--- a/src/components/ActionTestingView/index.jsx
+++ b/src/components/ActionTestingView/index.jsx
@@ -20,11 +20,14 @@ import downloadProject from '../../actions/downloadProject';
 import duplicateProject from '../../actions/duplicateProject';
 import deleteProject from '../../actions/deleteProject';
 import getProjectsArchive from '../../actions/getProjectsArchive';
+import renameProject from '../../actions/renameProject';
+import renameIllustration from '../../actions/renameIllustration';
+import backupFiles from '../../actions/backupFiles';
 
 function SettingsWatcher() {
   const [settings, setSettings] = useState({});
   const [projects, setProjects] = useState({});
-  const [projectOne, setProjectOne] = useState({});
+  const [projectData, setProjectData] = useState({});
   const [preview, setPreview] = useState({});
   const [archive, setArchive] = useState({});
 
@@ -36,8 +39,26 @@ function SettingsWatcher() {
       const newProjects = await store.getProjectsList();
       setProjects(newProjects);
 
-      const newProjOne = await store.getProject('project-one');
-      setProjectOne(newProjOne);
+      const newProjectData = {};
+      try {
+        newProjectData['project-one'] = await store.getProject('project-one');
+      } catch (error) { /* ignore */ }
+      try {
+        newProjectData['project-two'] = await store.getProject('project-two');
+      } catch (error) { /* ignore */ }
+      try {
+        newProjectData['project-three'] = await store
+          .getProject('project-three');
+      } catch (error) { /* ignore */ }
+      try {
+        newProjectData['project-four'] = await store
+          .getProject('project-four');
+      } catch (error) { /* ignore */ }
+      try {
+        newProjectData['new-project'] = await store.getProject('new-project');
+      } catch (error) { /* ignore */ }
+
+      setProjectData(newProjectData);
 
       const newPreview = await store.getPreview();
       setPreview(newPreview);
@@ -59,7 +80,7 @@ function SettingsWatcher() {
           {
             settings,
             projects,
-            projectOne,
+            projectData,
             preview,
             archive,
           },
@@ -78,8 +99,8 @@ export default function ActionTestingView() {
         variant="solid"
         className="text-lg"
         onClick={onClick}
+        icon={<PlusIcon />}
       >
-        <PlusIcon className="h-6 mr-1" />
         {name}
       </Button>
       <br />
@@ -101,7 +122,12 @@ export default function ActionTestingView() {
 
         <TestButton
           name="Create Project"
-          onClick={() => createProject('Project One')}
+          onClick={() => createProject('New Project')}
+        />
+
+        <TestButton
+          name="Download Project"
+          onClick={() => downloadProject('project-one')}
         />
 
         <TestButton
@@ -155,8 +181,8 @@ export default function ActionTestingView() {
         />
 
         <TestButton
-          name="Download Project"
-          onClick={() => downloadProject('project-one')}
+          name="Backup Project"
+          onClick={() => backupFiles('project-one')}
         />
 
         <TestButton
@@ -165,100 +191,45 @@ export default function ActionTestingView() {
         />
 
         <TestButton
+          name="Rename Project"
+          onClick={() => renameProject('project-two', 'Project Three')}
+        />
+
+        <TestButton
+          name="Rename Illustration"
+          onClick={() => renameIllustration(
+            'project-three',
+            'my-cool-illustration',
+            'my-okay-illustration',
+          )}
+        />
+
+        <TestButton
           name="Delete Project"
           onClick={() => deleteProject('project-one')}
+        />
+      </div>
+      <br />
+      <h2>These Should Throw Errors</h2>
+
+      <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+        <TestButton
+          name="Create Existing Project"
+          onClick={() => createProject('Project One')}
+        />
+        <TestButton
+          name="Create Reserved Project"
+          onClick={() => createProject('projects')}
+        />
+        <TestButton
+          name="Rename Downloaded Project"
+          onClick={() => renameProject('project-one', 'project-two')}
+        />
+        <TestButton
+          name="Rename To Existing Project"
+          onClick={() => renameProject('new-project', 'project-one')}
         />
       </div>
     </div>
   );
 }
-
-// <Button
-// variant="solid"
-// className="text-lg"
-// // onClick={() => downloadTemplate()}
-// onClick={() => CreateProject('proj-1')}
-// >
-// <PlusIcon className="h-6 mr-1" />
-// Create Project
-
-// </Button>
-// <br />
-// <Button
-// variant="solid"
-// className="text-lg"
-// // onClick={() => downloadTemplate()}
-// onClick={() => CreateIllustration('proj-1', 'test-illo')}
-// >
-// <PlusIcon className="h-6 mr-1" />
-// Create Illustration
-// </Button>
-// <br />
-// <Button
-// variant="solid"
-// className="text-lg"
-// // onClick={() => downloadTemplate()}
-// onClick={() => OpenIllustration('proj-1', 'test-illo')}
-// >
-// Open Illustration
-// </Button>
-// <br />
-// <Button
-// variant="solid"
-// className="text-lg"
-// // onClick={() => downloadTemplate()}
-// onClick={() => Generate('proj-1', 'test-illo')}
-// >
-// Generate
-// </Button>
-// <br />
-// <Button
-// variant="solid"
-// className="text-lg"
-// onClick={() => Preview('proj-1')}
-// >
-// Preview
-
-// </Button>
-// <br />
-// <Button
-// variant="solid"
-// className="text-lg"
-// onClick={() => OutputShare('proj-1')}
-// >
-// Output Share
-
-// </Button>
-// <br />
-// <Button
-// variant="solid"
-// className="text-lg"
-// >
-// <a
-//   target="_blank"
-//   href={getSharePage('proj-1')}
-//   rel="noreferrer"
-// >
-//   Test Share
-// </a>
-
-// </Button>
-// <br />
-// <Button
-// variant="solid"
-// className="text-lg"
-// onClick={() => DuplicateProject('proj-1', 'proj-2')}
-// >
-// Duplicate Project
-
-// </Button>
-// <br />
-// <Button
-// variant="solid"
-// className="text-lg"
-// onClick={() => DeleteIllustration('proj-1', 'test-illo')}
-// >
-// Delete Illustration
-
-// </Button>
-// <br />

--- a/src/errors/store.js
+++ b/src/errors/store.js
@@ -8,10 +8,19 @@ export const PROJECT_NAME_EXISTS_ERROR = new Error(
   'Project name already exists. Slugs must be unique.',
 );
 
+export const ILLO_NAME_EXISTS_ERROR = new Error(
+  'Illustration name already exists in project. Slugs must be unique.',
+);
+
 export const NO_PROJECT_EXISTS_ERROR = new Error(
   'No such project exists.',
 );
 
 export const NO_ILLUSTRATION_EXISTS_ERROR = new Error(
   'No such illustration exists.',
+);
+
+export const PROJECT_NO_RENAME = new Error(
+  'Project is uploaded and cannot be renamed. Please contact'
+  + ' an Artisan admin to change the name of this project.',
 );

--- a/src/errors/store.js
+++ b/src/errors/store.js
@@ -22,5 +22,5 @@ export const NO_ILLUSTRATION_EXISTS_ERROR = new Error(
 
 export const PROJECT_NO_RENAME = new Error(
   'Project is uploaded and cannot be renamed. Please contact'
-  + ' an Artisan admin to change the name of this project.',
+  + ' an Artisan admin to change existing project or illustration names.',
 );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 
-import AppView from './components/AppView';
+import ActionTestingView from './components/ActionTestingView';
 import './main.css';
 
 ReactDOM.createRoot(window.document.getElementById('root')).render(
   <React.StrictMode>
-    <AppView />
+    <ActionTestingView />
   </React.StrictMode>,
 );

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -9,6 +9,8 @@ import getSettings from './operations/getSettings';
 import getWorkingDir from './operations/getWorkingDir';
 import removeIllustration from './operations/removeIllustration';
 import removeProject from './operations/removeProject';
+import renameProject from './operations/renameProject';
+import renameIllustration from './operations/renameIllustration';
 import updateIllustration from './operations/updateIllustration';
 import updatePreview from './operations/updatePreview';
 import updateProject from './operations/updateProject';
@@ -24,6 +26,8 @@ export default {
   getWorkingDir,
   removeIllustration,
   removeProject,
+  renameProject,
+  renameIllustration,
   updateIllustration,
   updatePreview,
   updateProject,

--- a/src/store/operations/addIllustration.js
+++ b/src/store/operations/addIllustration.js
@@ -1,4 +1,7 @@
 import { PROJECTS } from '../init';
+import slugify from '../../utils/text/slugify';
+import verifyProjectExists from '../verification/projectExists';
+import verifyIllustrationSlug from '../verification/validIllustrationSlug';
 
 /**
  * Adds an illustration to a project with `publicURL` set to `null`.
@@ -11,27 +14,27 @@ import { PROJECTS } from '../init';
 export default async function addIllustration(
   { projectSlug, illustrationName },
 ) {
+  await verifyProjectExists(projectSlug);
+
+  const slug = slugify(illustrationName);
+  await verifyIllustrationSlug(projectSlug, slug);
+
   const projectEntry = await PROJECTS.get(projectSlug);
 
-  if (projectEntry) {
-    const { illustrations } = projectEntry;
-    const slug = illustrationName.toLowerCase().replaceAll(' ', '-');
+  const { illustrations } = projectEntry;
 
-    const newIllustration = {
-      name: illustrationName,
-      slug,
-      publicURL: null,
-    };
+  const newIllustration = {
+    name: illustrationName,
+    slug,
+    publicURL: null,
+  };
 
-    await PROJECTS.set(projectSlug, {
-      ...projectEntry,
-      illustrations: [...illustrations, newIllustration],
-    });
+  await PROJECTS.set(projectSlug, {
+    ...projectEntry,
+    illustrations: [...illustrations, newIllustration],
+  });
 
-    await PROJECTS.save();
-
-    return PROJECTS.get(projectSlug);
-  }
+  await PROJECTS.save();
 
   return PROJECTS.get(projectSlug);
 }

--- a/src/store/operations/addProject.js
+++ b/src/store/operations/addProject.js
@@ -1,9 +1,7 @@
+import slugify from '../../utils/text/slugify';
 import { PROJECTS, STORE } from '../init';
 import { PROJECTS_LIST_NAME } from '../constants';
-import {
-  RESRVED_PROJECT_NAME_ERROR,
-  PROJECT_NAME_EXISTS_ERROR,
-} from '../../errors/store';
+import validProjectSlug from '../verification/validProjectSlug';
 
 /**
  * Add a project to the store's projects array
@@ -18,30 +16,29 @@ import {
  */
 export default async function addProject(
   projectName,
-  { isUploaded, isPublished, lastUploaded } = {},
+  {
+    isUploaded,
+    isPublished,
+    lastUploaded,
+    method,
+  } = {},
 ) {
   const projectsArr = await STORE.get(PROJECTS_LIST_NAME);
 
-  const projectSlug = projectName.toLowerCase().replaceAll(' ', '-');
+  const projectSlug = slugify(projectName);
 
-  if (projectSlug === PROJECTS_LIST_NAME) {
-    throw RESRVED_PROJECT_NAME_ERROR;
-  }
+  await validProjectSlug(projectSlug, { method });
 
-  const projectEntry = await PROJECTS.get(projectSlug);
-
-  if (projectEntry) {
-    throw PROJECT_NAME_EXISTS_ERROR;
-  }
-
-  await PROJECTS.set(projectSlug, {
+  const newProjectConfig = {
     isUploaded: isUploaded || false,
     isPublished: isPublished || false,
     lastUploaded: lastUploaded || null,
     name: projectName,
     slug: projectSlug,
     illustrations: [],
-  });
+  };
+
+  await PROJECTS.set(projectSlug, newProjectConfig);
 
   if (projectsArr) {
     await STORE.set(PROJECTS_LIST_NAME, [...projectsArr, projectSlug]);

--- a/src/store/operations/addProject.js
+++ b/src/store/operations/addProject.js
@@ -11,6 +11,7 @@ import validProjectSlug from '../verification/validProjectSlug';
  * @param {String} [opts.isUploaded]
  * @param {String} [opts.isPublished]
  * @param {String} [opts.lastUploaded]
+ * @param {String} [opts.method]
  * @returns {Promise<import('../types').ProjectDetails | null>}
  * Project detail object
  */

--- a/src/store/operations/getPreview.js
+++ b/src/store/operations/getPreview.js
@@ -5,7 +5,7 @@ import {
   PREFERRED_PORT,
 } from '../constants';
 
-export default async function getPreviewPid() {
+export default async function getPreview() {
   const pid = await STORE.get(ACTIVE_PREVIEW_PROCESS);
   const project = await STORE.get(ACTIVE_PREVIEW_PROJECT);
   const port = await STORE.get(PREFERRED_PORT);

--- a/src/store/operations/getProject.js
+++ b/src/store/operations/getProject.js
@@ -1,4 +1,5 @@
 import { PROJECTS } from '../init';
+import verifyProjectExists from '../verification/projectExists';
 
 /**
  * Returns a project for a given `key` or `null` if the project doesn't exist.
@@ -6,5 +7,6 @@ import { PROJECTS } from '../init';
  * @returns {Promise<import('../types').ProjectDetails | null>}
  */
 export default async function getProject(key) {
+  await verifyProjectExists(key);
   return PROJECTS.get(key);
 }

--- a/src/store/operations/removeIllustration.js
+++ b/src/store/operations/removeIllustration.js
@@ -1,7 +1,5 @@
 import { PROJECTS } from '../init';
-import {
-  NO_PROJECT_EXISTS_ERROR,
-} from '../../errors/store';
+import verifyIlloExists from '../verification/illustrationExists';
 
 /**
  * Removes an illustration from a project.
@@ -13,11 +11,8 @@ import {
 export default async function removeIllustration(
   { projectSlug, illustrationSlug },
 ) {
+  await verifyIlloExists(projectSlug, illustrationSlug);
   const projectEntry = await PROJECTS.get(projectSlug);
-
-  if (!projectEntry) {
-    throw NO_PROJECT_EXISTS_ERROR;
-  }
 
   const { illustrations } = projectEntry;
   const illosUpdated = illustrations.filter(

--- a/src/store/operations/removeProject.js
+++ b/src/store/operations/removeProject.js
@@ -1,5 +1,6 @@
 import { PROJECTS, STORE } from '../init';
 import { PROJECTS_LIST_NAME } from '../constants';
+import verifyProjectExists from '../verification/projectExists';
 
 /**
  * Remove a project from the store.
@@ -7,6 +8,8 @@ import { PROJECTS_LIST_NAME } from '../constants';
  * @param {String} projectsSlug Kebab-case project name string
  */
 export default async function removeProject(projectsSlug) {
+  await verifyProjectExists(projectsSlug);
+
   const projectsArr = await STORE.get('projects');
   const projectEntry = await PROJECTS.get(projectsSlug);
 

--- a/src/store/operations/renameIllustration.js
+++ b/src/store/operations/renameIllustration.js
@@ -1,7 +1,8 @@
 import { PROJECTS } from '../init';
+import { PROJECT_NO_RENAME } from '../../errors/store';
 import slugify from '../../utils/text/slugify';
-import getProject from './getProject';
 import verifyIlloExists from '../verification/illustrationExists';
+import validIllustrationSlug from '../verification/validIllustrationSlug';
 
 export default async function renameIllustration({
   project: projectSlug,
@@ -11,7 +12,13 @@ export default async function renameIllustration({
   await verifyIlloExists(projectSlug, slug);
 
   const newIlloSlug = slugify(name);
-  const projectInfo = await getProject(projectSlug);
+  await validIllustrationSlug(projectSlug, newIlloSlug);
+
+  const projectInfo = await PROJECTS.get(projectSlug);
+  if (projectInfo.isUploaded) {
+    throw PROJECT_NO_RENAME;
+  }
+
   const illoInfo = projectInfo
     .illustrations
     .find((illo) => illo.slug === slug);

--- a/src/store/operations/renameIllustration.js
+++ b/src/store/operations/renameIllustration.js
@@ -1,0 +1,38 @@
+import { PROJECTS } from '../init';
+import slugify from '../../utils/text/slugify';
+import getProject from './getProject';
+import verifyIlloExists from '../verification/illustrationExists';
+
+export default async function renameIllustration({
+  project: projectSlug,
+  slug,
+  name,
+}) {
+  await verifyIlloExists(projectSlug, slug);
+
+  const newIlloSlug = slugify(name);
+  const projectInfo = await getProject(projectSlug);
+  const illoInfo = projectInfo
+    .illustrations
+    .find((illo) => illo.slug === slug);
+
+  PROJECTS.set(projectSlug, {
+    ...projectInfo,
+    illustrations: [
+      ...projectInfo.illustrations.filter((illo) => illo.slug !== slug),
+      {
+        ...illoInfo,
+        name,
+        slug: newIlloSlug,
+      },
+    ],
+  });
+
+  await PROJECTS.save();
+
+  const newProjectsInfo = await PROJECTS.get(projectSlug);
+  const newIlloInfo = newProjectsInfo
+    .illustrations.find((illo) => illo.slug === newIlloSlug);
+
+  return newIlloInfo || {};
+}

--- a/src/store/operations/renameProject.js
+++ b/src/store/operations/renameProject.js
@@ -1,0 +1,41 @@
+import { PROJECTS, STORE } from '../init';
+import { PROJECTS_LIST_NAME } from '../constants';
+import { PROJECT_NO_RENAME } from '../../errors/store';
+import slugify from '../../utils/text/slugify';
+import verifyProjectExists from '../verification/projectExists';
+import validProjectSlug from '../verification/validProjectSlug';
+
+export default async function renameProject({
+  slug,
+  name,
+}) {
+  await verifyProjectExists(slug);
+
+  const newProjectSlug = slugify(name);
+  await validProjectSlug(newProjectSlug, { method: 'rename' });
+
+  const projectInfo = await PROJECTS.get(slug);
+  if (projectInfo.isUploaded) {
+    throw PROJECT_NO_RENAME;
+  }
+
+  const projectsArr = await STORE.get(PROJECTS_LIST_NAME);
+  STORE.set(PROJECTS_LIST_NAME, [
+    ...projectsArr.filter((fSlug) => fSlug !== slug),
+    newProjectSlug,
+  ]);
+
+  PROJECTS.set(newProjectSlug, {
+    ...projectInfo,
+    name,
+    slug: newProjectSlug,
+  });
+  PROJECTS.delete(slug);
+
+  await Promise.all([
+    STORE.save(),
+    PROJECTS.save(),
+  ]);
+
+  return PROJECTS.get(newProjectSlug);
+}

--- a/src/store/operations/updateIllustration.js
+++ b/src/store/operations/updateIllustration.js
@@ -1,8 +1,5 @@
 import { PROJECTS } from '../init';
-import {
-  NO_PROJECT_EXISTS_ERROR,
-  NO_ILLUSTRATION_EXISTS_ERROR,
-} from '../../errors/store';
+import verifyIlloExists from '../verification/illustrationExists';
 
 /**
  * Updates an illustration's public URL field.
@@ -18,20 +15,14 @@ export default async function updateIllustrationURL({
   illustrationSlug,
   publicURL,
 }) {
-  const projectEntry = await PROJECTS.get(projectSlug);
+  await verifyIlloExists(projectSlug, illustrationSlug);
 
-  if (!projectEntry) {
-    throw NO_PROJECT_EXISTS_ERROR;
-  }
+  const projectEntry = await PROJECTS.get(projectSlug);
 
   const { illustrations } = projectEntry;
   const illoIndex = illustrations.findIndex(
     (d) => d.slug === illustrationSlug,
   );
-
-  if (illoIndex < 0) {
-    throw NO_ILLUSTRATION_EXISTS_ERROR;
-  }
 
   const illosUpdated = illustrations.map((d, i) => {
     if (i === illoIndex) {

--- a/src/store/operations/updatePreview.js
+++ b/src/store/operations/updatePreview.js
@@ -7,5 +7,6 @@ import {
 export default async function updatePreview(projectSlug, pid) {
   await STORE.set(ACTIVE_PREVIEW_PROCESS, pid);
   await STORE.set(ACTIVE_PREVIEW_PROJECT, projectSlug);
+
   await STORE.save();
 }

--- a/src/store/operations/updateProject.js
+++ b/src/store/operations/updateProject.js
@@ -1,7 +1,5 @@
 import { PROJECTS } from '../init';
-import {
-  NO_PROJECT_EXISTS_ERROR,
-} from '../../errors/store';
+import verifyProjectExists from '../verification/projectExists';
 
 /**
  * Update a project's upload state and last uploaded timestamp
@@ -21,11 +19,9 @@ export default async function updateProject(
     lastUploaded = null,
   } = {},
 ) {
-  const projectEntry = await PROJECTS.get(projectSlug);
+  await verifyProjectExists(projectSlug);
 
-  if (!projectEntry) {
-    throw NO_PROJECT_EXISTS_ERROR;
-  }
+  const projectEntry = await PROJECTS.get(projectSlug);
 
   await PROJECTS.set(projectSlug, {
     ...projectEntry,

--- a/src/store/verification/illustrationExists.js
+++ b/src/store/verification/illustrationExists.js
@@ -1,0 +1,26 @@
+import { PROJECTS } from '../init';
+import {
+  NO_ILLUSTRATION_EXISTS_ERROR,
+  NO_PROJECT_EXISTS_ERROR,
+} from '../../errors/store';
+
+export default async function illustrationExists(
+  projectSlug,
+  illustrationSlug,
+) {
+  const project = await PROJECTS.get(projectSlug);
+
+  if (!project) {
+    throw NO_PROJECT_EXISTS_ERROR;
+  }
+
+  const exists = project
+    .illustrations
+    .find((illo) => illo.slug === illustrationSlug);
+
+  if (!exists) {
+    throw NO_ILLUSTRATION_EXISTS_ERROR;
+  }
+
+  return true;
+}

--- a/src/store/verification/projectExists.js
+++ b/src/store/verification/projectExists.js
@@ -1,0 +1,12 @@
+import { PROJECTS } from '../init';
+import { NO_PROJECT_EXISTS_ERROR } from '../../errors/store';
+
+export default async function projectExists(projectSlug) {
+  const exists = await PROJECTS.has(projectSlug);
+
+  if (!exists) {
+    throw NO_PROJECT_EXISTS_ERROR;
+  }
+
+  return true;
+}

--- a/src/store/verification/validIllustrationSlug.js
+++ b/src/store/verification/validIllustrationSlug.js
@@ -1,0 +1,20 @@
+import { PROJECTS } from '../init';
+import {
+  ILLO_NAME_EXISTS_ERROR,
+} from '../../errors/store';
+
+export default async function validIllustrationSlug(
+  projectSlug,
+  illustrationSlug,
+) {
+  const project = await PROJECTS.get(projectSlug);
+  const existingIlloIdx = project
+    .illustrations
+    .findIndex((illo) => illo.slug === illustrationSlug);
+
+  if (existingIlloIdx > -1) {
+    throw ILLO_NAME_EXISTS_ERROR;
+  }
+
+  return true;
+}

--- a/src/store/verification/validIllustrationSlug.js
+++ b/src/store/verification/validIllustrationSlug.js
@@ -8,6 +8,7 @@ export default async function validIllustrationSlug(
   illustrationSlug,
 ) {
   const project = await PROJECTS.get(projectSlug);
+
   const existingIlloIdx = project
     .illustrations
     .findIndex((illo) => illo.slug === illustrationSlug);

--- a/src/store/verification/validProjectSlug.js
+++ b/src/store/verification/validProjectSlug.js
@@ -1,0 +1,29 @@
+import { PROJECTS } from '../init';
+import { PROJECTS_LIST_NAME } from '../constants';
+import {
+  RESRVED_PROJECT_NAME_ERROR,
+  PROJECT_NAME_EXISTS_ERROR,
+} from '../../errors/store';
+
+import fetchProjectsArchive from '../../utils/archive/fetchProjectsArchive';
+
+export default async function validProjectSlug(projectSlug, { method } = {}) {
+  if (projectSlug === PROJECTS_LIST_NAME) {
+    throw RESRVED_PROJECT_NAME_ERROR;
+  }
+
+  const projectEntry = await PROJECTS.get(projectSlug);
+
+  if (projectEntry) {
+    throw PROJECT_NAME_EXISTS_ERROR;
+  }
+
+  if (method !== 'download') {
+    const archive = await fetchProjectsArchive();
+    if (archive.find((archiveSlug) => archiveSlug === projectSlug)) {
+      throw PROJECT_NAME_EXISTS_ERROR;
+    }
+  }
+
+  return true;
+}

--- a/src/utils/archive/fetchProjectsArchive.js
+++ b/src/utils/archive/fetchProjectsArchive.js
@@ -1,23 +1,19 @@
 /* eslint-disable import/prefer-default-export */
 import { ARCHIVE_PROJECTS_DIRECTORY } from '../../constants/paths';
 import { AWS_ARTISAN_BUCKET } from '../../constants/aws';
-import store from '../../store';
 import s3 from '../s3';
 
 export default async function fetchProjectsArchive() {
-  const projectsPrefixes = s3.list({
+  const params = {
     bucket: AWS_ARTISAN_BUCKET,
-    prefix: ARCHIVE_PROJECTS_DIRECTORY,
-  });
+    delimiter: '/',
+    prefix: `${ARCHIVE_PROJECTS_DIRECTORY}/`,
+  };
 
-  const projectsList = projectsPrefixes.CommonPrefixes.map((d) => {
+  const projectsPrefixes = await s3.list(params);
+
+  return projectsPrefixes?.CommonPrefixes.map((d) => {
     const path = d.Prefix;
-    return path.replace(ARCHIVE_PROJECTS_DIRECTORY, '').replace('/', '');
+    return path.replace(`${ARCHIVE_PROJECTS_DIRECTORY}/`, '').replace('/', '');
   });
-
-  // compare to projects in store
-  const localProjects = (await store.getProjectsList()) || [];
-
-  // Return projects not locally in the settigns store
-  return projectsList.filter((p) => !localProjects.includes(p));
 }


### PR DESCRIPTION
Adds two new actions
- renameProject
- renameIllustration

(Neither action can be preformed on a project that has already been backed up).

## To Test
Start Tauri dev and run the following

- Initialize
- Download Project (should see 'project-one' downloaded)
- Duplicate Project (should see 'project-two' created)
- Rename Project (should see it changed to 'project-three')
- Rename Illustration (should see the illo in project three changed to 'my-okay-illustration')

## To Test Error Handing

Project Already Exists
- Initialize 
- Create Existing Project (should throw error indicating project name exists)
- Initialize
- Create Project (should see a new project called 'new-project')
- Rename To Existing Project  (should throw error indicating project name exists)

Project Name Invalid
- Initialize
- Create Reserved Project (should throw error indicating reserved word for project name)

Project Can't Renamed
- Initialize
- Download Project (should see 'project-one' downloaded)
- Rename Downloaded Project (should see error indicating the project backed up and can't be renamed)

Illustration Already Exists & Illustration Can't Renamed
- Initialize
- Download Project (should see 'project-one' downloaded)
- Create Illustration Two (should see 'my-second-illustration' added)
- Rename to Existing Illustration (should see error indicating that illustration already exists)
- Rename Backed Up Illustrations (should see error indicating the project backed up and can't be renamed)