### PR TITLE
Skeleton fallback loading component and Error Status Icon state

### DIFF
--- a/src/actions/getProjectsArchive.js
+++ b/src/actions/getProjectsArchive.js
@@ -16,7 +16,7 @@ export default async function getProjectsArchive() {
 
   // Return projects not locally in the settigns store
   const archivedProjects = projectsList.filter(
-    ({ slug }) => !localProjects.includes({ slug }),
+    ({ slug }) => !localProjects.includes(slug),
   );
 
   return Promise.all(

--- a/src/components/IllustrationList/index.jsx
+++ b/src/components/IllustrationList/index.jsx
@@ -1,6 +1,9 @@
 import cls from 'classnames';
+import { useState, useEffect } from 'react';
+import { borders } from '../../theme';
 import IllustrationItem from '../IllustrationItem';
 import NewIllustration from '../NewIllustration';
+import Skeleton from '../Skeleton';
 import styles from './styles.module.css';
 
 export default function Illustrationlist({
@@ -8,7 +11,32 @@ export default function Illustrationlist({
   selectedProject,
   isArchive,
 }) {
+  const [isLoading, setIsLoading] = useState(true);
   const containerClass = cls(styles.container);
+
+  useEffect(() => {
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 1500);
+  }, [selectedProject]);
+
+  if (isLoading) {
+    return (
+      <div className={containerClass}>
+        <Skeleton
+          className={cls(styles.skeleton, borders.roundedMd)}
+          width="230px"
+          height="180px"
+        />
+        <Skeleton
+          className={cls(styles.skeleton, borders.roundedMd)}
+          width="230px"
+          height="180px"
+        />
+      </div>
+    );
+  }
 
   return (
     <div className={containerClass}>

--- a/src/components/ProjectList/index.jsx
+++ b/src/components/ProjectList/index.jsx
@@ -24,7 +24,7 @@ export default function ProjectList({
     (async () => {
       if (selectedIndex === 0) {
         const projects = await store.getProjectsList();
-        setProjectsList([]);
+        setProjectsList(projects || []);
         setSelectedProject(projects[0] || null);
       } else {
         const archive = await getProjectsArchive();

--- a/src/components/ProjectList/index.jsx
+++ b/src/components/ProjectList/index.jsx
@@ -24,7 +24,7 @@ export default function ProjectList({
     (async () => {
       if (selectedIndex === 0) {
         const projects = await store.getProjectsList();
-        setProjectsList(projects || []);
+        setProjectsList(projects);
         setSelectedProject(projects[0] || null);
       } else {
         const archive = await getProjectsArchive();

--- a/src/components/ProjectListItem/index.jsx
+++ b/src/components/ProjectListItem/index.jsx
@@ -13,6 +13,7 @@ import {
   colors,
   typography as type,
 } from '../../theme';
+import Skeleton from '../Skeleton';
 
 export default function ProjectListItem({
   last,
@@ -25,7 +26,7 @@ export default function ProjectListItem({
 }) {
   const [projectDetail, setProjectDetail] = useState();
   const [status, setStatus] = useState(undefined);
-  const [projectName, setProjectName] = useState('...');
+  const [projectName, setProjectName] = useState(null);
 
   useEffect(() => {
     (async () => {
@@ -37,7 +38,7 @@ export default function ProjectListItem({
         setProjectName(archiveProject.name);
       }
     })();
-  });
+  }, [projectSlug, archiveProject]);
 
   useEffect(() => {
     if (projectDetail) {
@@ -72,19 +73,41 @@ export default function ProjectListItem({
     <>
       {(index > 0 || last) && <div className={styles.divider} />}
       <li>
-        <button
-          type="button"
-          className={itemClass}
-          onClick={() => setSelectedProject(archiveProject || projectSlug)}
-        >
-          <ProjectStatusIcon
-            className={styles.icon}
-            status={status}
-          />
-          <p className={cls(styles.itemName, type.textLg, margin.ml1)}>
-            {projectName}
-          </p>
-        </button>
+        {!projectName ? (
+          <div
+            className={cls(
+              flex.flex,
+              layout.itemsCenter,
+              padding.py1,
+              padding.px2,
+            )}
+          >
+            <Skeleton
+              height="24px"
+              width="24px"
+              variant="circle"
+            />
+            <Skeleton
+              height="20px"
+              width="75%"
+              className={cls(margin.ml2, margin.my1, borders.roundedLg)}
+            />
+          </div>
+        ) : (
+          <button
+            type="button"
+            className={itemClass}
+            onClick={() => setSelectedProject(archiveProject || projectSlug)}
+          >
+            <ProjectStatusIcon
+              className={styles.icon}
+              status={status}
+            />
+            <p className={cls(styles.itemName, type.textLg, margin.ml1)}>
+              {projectName}
+            </p>
+          </button>
+        )}
       </li>
     </>
   );

--- a/src/components/ProjectStatusIcon/icons.js
+++ b/src/components/ProjectStatusIcon/icons.js
@@ -1,8 +1,13 @@
-import { CheckCircleIcon, MinusCircleIcon } from '@heroicons/react/24/solid';
+import {
+  CheckCircleIcon,
+  MinusCircleIcon,
+  ExclamationCircleIcon,
+} from '@heroicons/react/20/solid';
 import ArchiveIcon from './ArchiveIcon';
 
 export const ICONS = {
   published: CheckCircleIcon,
   archive: ArchiveIcon,
   default: MinusCircleIcon,
+  error: ExclamationCircleIcon,
 };

--- a/src/components/ProjectStatusIcon/index.jsx
+++ b/src/components/ProjectStatusIcon/index.jsx
@@ -6,7 +6,8 @@ import styles from './styles.module.css';
  *
  * @param {Object} props
  * @param {('md' | 'lg')} [props.size=md] Icon size. Medium or large
- * @param {('published' | 'archive')} [props.status] Published or archive.
+ * @param {('published' | 'archive' | 'error')} [props.status] -
+ * Icon state either 'published', 'archive' or 'error'
  * Otherwise dispalys `"MinuseCircleIcon"`
  * @returns {JSX.Element}
  */

--- a/src/components/ProjectStatusIcon/styles.module.css
+++ b/src/components/ProjectStatusIcon/styles.module.css
@@ -14,6 +14,10 @@
   color: var(--slate-600);
 }
 
+.error {
+  color: var(--red-500);
+}
+
 .published {
   color: var(--emerald-500);
 }

--- a/src/components/ProjectToolbar/index.jsx
+++ b/src/components/ProjectToolbar/index.jsx
@@ -3,15 +3,30 @@ import { useEffect, useState } from 'react';
 import ProjectStatusIcon from '../ProjectStatusIcon';
 import ProjectStatusDek from '../ProjectStatusDek';
 import {
-  flex, layout, margin, colors, typography as type,
+  flex,
+  layout,
+  margin,
+  colors,
+  typography as type,
+  gap,
+  borders,
 } from '../../theme';
 import ButtonsGroup from './ButtonsGroup';
 import store from '../../store';
+import Skeleton from '../Skeleton';
 
 export default function ProjectToolbar({ selectedProject, isArchive }) {
+  const [isLoading, setIsLoading] = useState(true);
   const [projectDetail, setProjectDetail] = useState({});
   const [status, setStatus] = useState(undefined);
   const [timestamp, setTimestamp] = useState(undefined);
+
+  useEffect(() => {
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 1500);
+  }, [selectedProject]);
 
   // Gets project details when selected project changes
   useEffect(() => {
@@ -62,6 +77,40 @@ export default function ProjectToolbar({ selectedProject, isArchive }) {
       setTimestamp(undefined);
     };
   }, [projectDetail]);
+
+  if (isLoading) {
+    return (
+      <div
+        className={cls(
+          flex.flex,
+          flex.flexRow,
+          layout.itemsCenter,
+          margin.my2,
+        )}
+      >
+        <Skeleton
+          variant="circle"
+          width="26px"
+          height="26px"
+        />
+        <div
+          className={cls(flex.flex, flex.flexCol, gap.y3, margin.ml2)}
+          style={{ width: '60%' }}
+        >
+          <Skeleton
+            className={borders.roundedMd}
+            width="100%"
+            height="28px"
+          />
+          <Skeleton
+            className={borders.roundedMd}
+            width="100%"
+            height="12px"
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/components/Skeleton/index.jsx
+++ b/src/components/Skeleton/index.jsx
@@ -1,6 +1,18 @@
 import cls from 'classnames';
+import React from 'react';
 import styles from './styles.module.css';
 
+/**
+ * Skeleton component for loading content
+ * @type {React.ComponentPropsWithoutRef}
+ * @param {Object} props
+ * @param {"rectangle"|"circle"} [props.variant] -
+ * Display as rounded rectangle or cicle
+ * @param {String} props.height Height of skeleton element
+ * @param {String} props.width Width of skeleton element
+ * @param {String} [props.className] Custom classes
+ * @returns {import('react').ReactComponentElement}
+ */
 export default function Skeleton({
   variant = 'rectangle',
   height,
@@ -10,7 +22,6 @@ export default function Skeleton({
   return (
     <div
       className={cls(styles.skeleton, styles[variant], className)}
-      width={width}
       style={{
         width,
         height,

--- a/src/components/Skeleton/index.jsx
+++ b/src/components/Skeleton/index.jsx
@@ -1,0 +1,20 @@
+import cls from 'classnames';
+import styles from './styles.module.css';
+
+export default function Skeleton({
+  variant = 'rectangle',
+  height,
+  width,
+  className = '',
+}) {
+  return (
+    <div
+      className={cls(styles.skeleton, styles[variant], className)}
+      width={width}
+      style={{
+        width,
+        height,
+      }}
+    />
+  );
+}

--- a/src/components/Skeleton/styles.module.css
+++ b/src/components/Skeleton/styles.module.css
@@ -1,0 +1,35 @@
+.skeleton {
+  background: var(--slate-300);
+  -webkit-mask-image: -webkit-radial-gradient(white, black);
+}
+
+.skeleton::after {
+  animation: shine 1.6s linear 0.5s infinite;
+  background: linear-gradient(90deg, transparent, hsl(213, 27%, 77%), transparent);
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  top: 0;
+}
+
+.circle {
+  border-radius: 100%;
+}
+
+.illo {
+  background-color: var(--slate-200);
+}
+
+@keyframes shine {
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}

--- a/src/components/Skeleton/styles.module.css
+++ b/src/components/Skeleton/styles.module.css
@@ -18,10 +18,6 @@
   border-radius: 100%;
 }
 
-.illo {
-  background-color: var(--slate-200);
-}
-
 @keyframes shine {
   0% {
     transform: translateX(-100%);

--- a/src/theme/modules/gap.module.css
+++ b/src/theme/modules/gap.module.css
@@ -29,3 +29,13 @@
   --gap-y: 1;
   row-gap: calc(.25rem * var(--gap-y));
 }
+
+.y-2  {
+  --gap-y: 2;
+  row-gap: calc(.25rem * var(--gap-y));
+}
+
+.y-3  {
+  --gap-y: 3;
+  row-gap: calc(.25rem * var(--gap-y));
+}

--- a/src/theme/modules/margin.module.css
+++ b/src/theme/modules/margin.module.css
@@ -72,6 +72,11 @@
   margin-left: calc(0.25rem * var(--ml));
 }
 
+.ml-2 {
+  --ml: 2;
+  margin-left: calc(0.25rem * var(--ml));
+}
+
 /* RIGHT */
 .mr-1 {
   --mr: 1;


### PR DESCRIPTION
## New
* `<Skeleton>`
   * Basic loading component that can be configured with a width and height, custom class and includes a "circle" variant for status icon placeholders.
* Added `"error"` status to `ProjectStatusIcon`. When `status="error"` the icon will display as a red exclamation point in the list and toolbar.

## Changes
* Added fake "loading" timers to `IllustrationList` and `ProjectToolbar` just to test the loading skeleton.
* The skeleton for `ProjectList` works correctly since there is a buffer between loading the archive list.

## Fixes
* `action.getProjectsArcive()` now properly filters out local projects for its list
* `<ProjectList>` state now only sets itself from `projects` since it will always be an array
